### PR TITLE
Fix entry point to use calculator.py instead of __main__.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 dependencies = ["scipy","mcp"]
 
 [project.scripts]
-medcalc = "medcalc.__main__:main"
+medcalc = "medcalc.calculator:main"
 
 [tool.setuptools]
 packages = ["medcalc"]


### PR DESCRIPTION
## Bug: only 22 out of 59 tools are exposed via MCP/API

`pyproject.toml` was pointing the `medcalc` entry point at `medcalc.__main__:main`, but `__main__.py` only contains 22 `@mcp.tool()` definitions. The complete set of 59 tools lives in `calculator.py`, which also has its own `main()` function — but was never wired up as the entry point.

**Fix:** change the entry point to `medcalc.calculator:main`.

**To reproduce:**
```bash
pip install git+https://github.com/vitaldb/medcalc.git
mcpo --port 8000 -- medcalc
# only 22 operationIds appear in /openapi.json

**After fix:**
# all 59 operationIds appear in /openapi.json